### PR TITLE
Add Opscode platform support via url_path method

### DIFF
--- a/lib/spice.rb
+++ b/lib/spice.rb
@@ -17,7 +17,7 @@ require 'spice/mock'
 module Spice
   
   class << self
-    attr_writer :host, :port, :scheme, :client_name, :connection, :key_file, :raw_key
+    attr_writer :host, :port, :scheme, :url_path, :client_name, :connection, :key_file, :raw_key
     
     def default_host
       @default_host || "localhost"
@@ -31,6 +31,10 @@ module Spice
       @default_scheme || "http"
     end
     
+    def default_url_path
+      @default_url_path || ""
+    end
+    
     def host
       @host || default_host
     end
@@ -41,6 +45,10 @@ module Spice
     
     def scheme
       @scheme || default_scheme
+    end
+    
+    def url_path
+      @url_path || default_url_path
     end
     
     def client_name
@@ -65,20 +73,20 @@ module Spice
     def connection
       @connection
     end
-
+    
     def connect!
       @connection = Connection.new(
-        :url => "#{scheme}://#{host}:#{port}", 
+        :url => "#{scheme}://#{host}:#{port}#{url_path}", 
         :client_name => client_name, 
         :key_file => key_file
       )
     end
     
-    
     def reset!
       @host = default_host
       @port = default_port
       @scheme = default_scheme
+      @url_path = default_url_path
       @key_file = nil
       @client_name = nil
       @connection = nil

--- a/lib/spice/authentication.rb
+++ b/lib/spice/authentication.rb
@@ -23,6 +23,8 @@ module Spice
       sign_obj = Mixlib::Authentication::SignedHeaderAuth.signing_object(request_params)
       signed = sign_obj.sign(key).merge({:host => host})
       signed.inject({}){|memo, kv| memo["#{kv[0].to_s.upcase}"] = kv[1];memo}
+      version = {"X-Chef-Version" => "0.9.12"} # Platform requires X-Chef-Version header
+      signed.merge!(version)
     end
     
     private

--- a/lib/spice/connection.rb
+++ b/lib/spice/connection.rb
@@ -10,21 +10,20 @@ module Spice
       @host             = endpoint.host
       @scheme           = endpoint.scheme
       @port             = endpoint.port
-      @path             = endpoint.path
-      @path = URI.parse(@url).path
+      @url_path         = endpoint.path
       @auth_credentials = Authentication.new(options[:client_name], options[:key_file])
       @sign_on_redirect, @sign_request = true, true
     end
     
     def get(path, headers={})
-      begin
+      # begin
         RestClient.get(
           "#{@url}#{path}", 
-          build_headers(:GET, path, headers)
+          build_headers(:GET, "#{@url_path}#{path}", headers)
         )
-      rescue => e
-        e.response
-      end
+      # rescue => e
+      #   e.response
+      # end
     end
     
     def post(path, payload, headers={})
@@ -32,7 +31,7 @@ module Spice
         RestClient.post(
           "#{@url}#{path}",
           JSON.generate(payload),
-          build_headers(:POST, path, headers, JSON.generate(payload))
+          build_headers(:POST, "#{@url_path}#{path}", headers, JSON.generate(payload))
         )
       rescue => e
         e.response
@@ -44,7 +43,7 @@ module Spice
         RestClient.put(
           "#{@url}#{path}",
           JSON.generate(payload),
-          build_headers(:PUT, path, headers, JSON.generate(payload))
+          build_headers(:PUT, "#{@url_path}#{path}", headers, JSON.generate(payload))
         )
       rescue => e
         e.response
@@ -55,7 +54,7 @@ module Spice
       begin
         RestClient.delete(
           "#{@url}#{path}",
-          build_headers(:DELETE, path, headers)
+          build_headers(:DELETE, "#{@url_path}#{path}", headers)
         )
       rescue => e
         e.response
@@ -73,7 +72,7 @@ module Spice
         :http_method => method, 
         :path => path,
         :body => json_body, 
-        :host => "#{@scheme}://#{@host}:#{@port}#{@path}"
+        :host => "#{@host}:#{@port}"
       }
       request_params[:body] ||= ""
       auth_credentials.signature_headers(request_params)

--- a/spec/spice_spec.rb
+++ b/spec/spice_spec.rb
@@ -29,6 +29,15 @@ describe "Spice" do
     end
   end
   
+  describe ".default_url_path" do
+    it "should default to ''" do
+      Spice.default_url_path.should == ""
+    end
+    it "should not be settable" do
+      lambda { Spice.default_url_path = "/woohah" }.should raise_error
+    end
+  end
+  
   describe ".host" do
     it "should default to 'localhost' if not set" do
       Spice.host.should == "localhost"
@@ -56,6 +65,16 @@ describe "Spice" do
     it "should be settable" do
       Spice.scheme = 'https'
       Spice.scheme.should == 'https'
+    end
+  end
+  
+  describe ".url_path" do
+    it "should default to '' if not set" do
+      Spice.url_path.should == ""
+    end
+    it "should be settable" do
+      Spice.url_path = "/woohah"
+      Spice.url_path.should == "/woohah"
     end
   end
   


### PR DESCRIPTION
Hi Dan,

Spice rules!

I needed support for the Opscode platform so I added a new config variable `url_path`, which will preface all requests. I also included a new header: `X-Chef-Version`, which according to the opscode dudes, is required when accessing the platform. Tests are included, but since I don't have my own chef server to test, I wasn't able to run the full suite.

Thanks!
