### PR TITLE
Rebuild search

### DIFF
--- a/lib/spice.rb
+++ b/lib/spice.rb
@@ -1,6 +1,7 @@
 require 'rest-client'
 require 'mixlib/authentication'
 require 'yajl'
+require 'cgi'
 
 require 'spice/authentication'
 require 'spice/chef'
@@ -17,70 +18,70 @@ require 'spice/version'
 require 'spice/mock'
 
 module Spice
-  
+
   class << self
     attr_writer :host, :port, :scheme, :url_path, :client_name, :connection, :key_file, :raw_key
-    
+
     def default_host
       @default_host || "localhost"
     end
-    
+
     def default_port
       @default_port || "4000"
     end
-    
+
     def default_scheme
       @default_scheme || "http"
     end
-    
+
     def default_url_path
       @default_url_path || ""
     end
-    
+
     def host
       @host || default_host
     end
-    
+
     def port
       @port || default_port
     end
-    
+
     def scheme
       @scheme || default_scheme
     end
-    
+
     def client_name
       @client_name
     end
-    
+
     def key_file
       @key_file
     end
-    
+
     def raw_key
       @raw_key
     end
-    
+
     def key_file=(new_key_file)
       raw_key = File.read(new_key_file)
       assert_valid_key_format!(raw_key)
       @key_file = new_key_file
       @raw_key = raw_key
     end
-    
-    
+
+
     def url_path
       @url_path || default_url_path
     end
-    
+
     def connection
       @connection
     end
 
     def connect!
       @connection = Connection.new(
-        :url => "#{scheme}://#{host}:#{port}/#{url_path}", 
-        :client_name => client_name, 
+        :url => "#{scheme}://#{host}:#{port}/#{url_path}",
+        :client_name => client_name,
         :key_file => key_file
       )
     end
@@ -93,17 +94,17 @@ module Spice
       @client_name = nil
       @connection = nil
     end
-    
+
     def setup
       yield self
     end
-    
+
     def mock
       Spice::Mock.setup_mock_client
     end
-    
+
     private
-    
+
     def assert_valid_key_format!(raw_key)
       unless (raw_key =~ /\A-----BEGIN RSA PRIVATE KEY-----$/) &&
          (raw_key =~ /^-----END RSA PRIVATE KEY-----\Z/)

--- a/lib/spice/search.rb
+++ b/lib/spice/search.rb
@@ -1,20 +1,23 @@
 module Spice
   class Search < Spice::Chef
-    INDEXES = %w(node role client users)
-    
-    INDEXES.each do |index|
-      define_method index do |options|
-        options ||= {}
-        options.symbolize_keys!
-        
-        type = index
-        query = options[:q] || '*:*'
-        sort = options[:sort] || "X_CHEF_id_CHEF_X asc"
-        start = options[:start] || 0
-        rows = options[:rows] || 1000
-        
-        connection.get("/search/#{index}?q=#{escape(query)}&sort=#{escape(sort)}&start=#{escape(start)}&rows=#{escape(rows)}")
-      end
+    def self.search(index, options={})
+      options = {:q => options} if options.is_a? String
+      options.symbolize_keys!
+
+      options[:q] ||= '*:*'
+      options[:sort] ||= "X_CHEF_id_CHEF_X asc"
+      options[:start] ||= 0
+      options[:rows] ||= 1000
+
+      # clean up options hash
+      options.delete_if{|k,v| !%w(q sort start rows).include?(k.to_s)}
+
+      params = options.collect{ |k, v| "#{k}=#{CGI::escape(v.to_s)}"}.join("&")
+      connection.get("/search/#{CGI::escape(index.to_s)}?#{params}")
+    end
+
+    def self.method_missing(*args, &block)
+      self.search(*args, &block)
     end
   end
 end


### PR DESCRIPTION
Search is now called by method_missing. This allows to search for arbitrary data bags. I also added a convenience API. If only a string is passed instead of a Hash, it is search for with default parameters.

Also fixed is the escaping which now uses CGI::escape. The original escape somehow got injected into my test environment...

This pull request should by used instead of https://github.com/danryan/spice/pull/6. Sorry for the noise and confusion. Guess we really need some specs here.
