### PR TITLE
Fix create_node and update_node method.

### DIFF
--- a/lib/spice/connection/nodes.rb
+++ b/lib/spice/connection/nodes.rb
@@ -32,14 +32,13 @@ module Spice
         get_node(node.name)
       end # def create_node
 
-      # TODO(dryan): be able to update a node
-      # def update_node(params=Mash.new)
-      #   node = Spice::Node.new(params)
-      #   node.attrs.update get_node(node.name)
-      #   attributes = put("/nodes/#{node.name}", node.attrs)
-      #   Spice::Node.get_or_new(attributes)
-      # end
-      
+      def update_node(params=Mash.new)
+        node = get_node(params[:name])
+        node.attrs.update Spice::Node.new(params)
+        put("/nodes/#{node.name}", node.attrs)
+        get_node(node.name)
+      end
+
     end # module Nodes
   end # class Connection
 end # module Spice

--- a/lib/spice/connection/nodes.rb
+++ b/lib/spice/connection/nodes.rb
@@ -25,12 +25,11 @@ module Spice
       end # def node
 
       alias :get_node :node
-      
+
       def create_node(params=Mash.new)
         node = Spice::Node.new(params)
-        node_attributes = post("/nodes", node.to_hash)
-        get_node("/nodes/#{node.name}")
-        Spice::Node.get_or_new(attributes)
+        post("/nodes", node.attrs)
+        get_node(node.name)
       end # def create_node
 
       # TODO(dryan): be able to update a node


### PR DESCRIPTION
```
commit 01dfdb3c45240ba125ca66573d29fc6edc349b92 (HEAD, origin/master, origin/HEAD, master)
Author: Johannes Plunien <johannes.plunien@xing.com>
Date:   Tue Jun 26 17:06:18 2012 +0200

    Fix update_node method.

commit bdd9afcd8107fb582263bccdab9a3727514456ed
Author: Johannes Plunien <johannes.plunien@xing.com>
Date:   Tue Jun 26 16:48:44 2012 +0200

    Fix create_node method.

    This was throwing a Spice::Error::NotFound exception because it was
    generating a wrong path (/nodes//nodes/...). The get_node() call at the
    end of the method returns the full node object. If just the attributes
    were used to create the node object, many things were missing.
```
